### PR TITLE
Update functionality of Add-on board improved

### DIFF
--- a/FLipWare/commands.cpp
+++ b/FLipWare/commands.cpp
@@ -450,8 +450,12 @@ void performCommand (uint8_t cmd, int16_t par1, char * keystring, int8_t periodi
 			break;
 		case CMD_UG:
 			//we set this flag here, flushing & disabling serial port is done in loop()
-			addonUpgrade = 2;
+      addonUpgrade = 2;
 			Serial.println("Starting upgrade for BT addon!");
+      // Command for upgrade sent to ESP - triggering reset into factory reset mode
+      Serial_AUX.println("$UG");
+      // delaying to ensure that UART command is sent and received
+      delay(500);
 			break;
         case CMD_E2:
       			DebugOutput=DEBUG_FULLOUTPUT; 
@@ -469,4 +473,3 @@ void performCommand (uint8_t cmd, int16_t par1, char * keystring, int8_t periodi
             break;
      }
 }
-

--- a/FLipWare/commands.h
+++ b/FLipWare/commands.h
@@ -11,7 +11,7 @@
           AT                returns "OK"
           AT ID             returns identification string (e.g. "FLipMouse V2.0")
           AT BC	<string>	sends parameter to external UART (mostly ESP32 Bluetooth Addon)
-          AT UG				puts Bluetooth addon into update mode & routes every USB serial byte to external Serial.
+          AT UG				puts Bluetooth addon into update mode (factory reset - mode) & routes every USB serial byte to external Serial.
 							Warning: cannot return from this mode, FLipMouse must be restarted then!
           AT BM <uint>      puts button into programming mode (e.g. "AT BM 2" -> next AT-command defines the new function for button 2)
                             for the FLipmouse, there are 11 buttons available (3 physical buttons, 8 virtual functions): 


### PR DESCRIPTION
The UART command AT UG now also  sends '$UG' to the Add-on board (ESP32). The command then sets the boot partition to 'factory' and restarts if operation was successful. The firmware (.bin file) can then be passed onto the Add-on board via Teensy-UART.