### PR TITLE
added command AT RC for resetting current slot to default config

### DIFF
--- a/FLipWare/commands.cpp
+++ b/FLipWare/commands.cpp
@@ -32,7 +32,7 @@ const struct atCommandType atCommands[] PROGMEM = {
   {"MY"  , PARTYPE_INT  },  {"KW"  , PARTYPE_STRING}, {"KP"  , PARTYPE_STRING}, {"KR"  , PARTYPE_STRING},
   {"RA"  , PARTYPE_NONE },  {"SA"  , PARTYPE_STRING}, {"LO"  , PARTYPE_STRING}, {"LA"  , PARTYPE_NONE },
   {"LI"  , PARTYPE_NONE },  {"NE"  , PARTYPE_NONE }, {"DE"  , PARTYPE_STRING }, {"RS"  , PARTYPE_NONE },
-  {"NC"  , PARTYPE_NONE },  {"MM"  , PARTYPE_UINT },
+  {"RC"  , PARTYPE_NONE },  {"NC"  , PARTYPE_NONE },  {"MM"  , PARTYPE_UINT },
   {"SW"  , PARTYPE_NONE },  {"SR"  , PARTYPE_NONE }, {"ER"  , PARTYPE_NONE }, {"CA"  , PARTYPE_NONE },
   {"AX"  , PARTYPE_UINT },  {"AY"  , PARTYPE_UINT }, {"DX"  , PARTYPE_UINT }, {"DY"  , PARTYPE_UINT },
   {"TS"  , PARTYPE_UINT },  {"TP"  , PARTYPE_UINT }, {"SP"  , PARTYPE_UINT }, {"SS"  , PARTYPE_UINT },
@@ -291,6 +291,15 @@ void performCommand (uint8_t cmd, int16_t par1, char * keystring, int8_t periodi
       saveToEEPROM(settings.slotName); //save default slot to default name
       readFromEEPROM(""); //load this slot
       Serial.println("OK");    // send AT command acknowledge
+      break;
+    case CMD_RC:
+      char tempName[MAX_NAME_LEN];
+      strcpy(tempName, settings.slotName);  // temporarily store current slot name
+      memcpy(&settings,&defaultSettings,sizeof(struct slotGeneralSettings)); //load default values from flash
+      initButtons(); //reset buttons
+      strcpy(settings.slotName, tempName);  // restore current slot name
+      saveToEEPROM(settings.slotName);
+      Serial.println("OK");
       break;
     case CMD_NC:
       break;

--- a/FLipWare/commands.h
+++ b/FLipWare/commands.h
@@ -93,6 +93,7 @@
           AT NE           next mode will be loaded (wrap around after last slot)
           AT DE <string>  delete slot of given name (deletes all stored slots if no string parameter is given)
           AT RS           resets FLipMouse and restores default configuration (deletes EEPROM and restores default Slot "mouse")
+          AT RC           resets current slot to default configuration and saves it to EEPROM
           AT NC           no command (idle operation)
           AT BT <uint>    set bluetooth mode, 1=USB only, 2=BT only, 3=both(default)
                           (e.g. AT BT 2 -> send HID commands only via BT if BT-daughter board is available)
@@ -177,7 +178,7 @@
 enum atCommands {
   CMD_ID, CMD_BM, CMD_CL, CMD_CR, CMD_CM, CMD_CD, CMD_PL, CMD_PR, CMD_PM, CMD_RL, CMD_RR, CMD_RM,
   CMD_WU, CMD_WD, CMD_WS, CMD_MX, CMD_MY, CMD_KW, CMD_KP, CMD_KR, CMD_RA, CMD_SA, CMD_LO, CMD_LA,
-  CMD_LI, CMD_NE, CMD_DE, CMD_RS, CMD_NC, CMD_MM, CMD_SW, CMD_SR, CMD_ER, CMD_CA, CMD_AX,
+  CMD_LI, CMD_NE, CMD_DE, CMD_RS, CMD_RC, CMD_NC, CMD_MM, CMD_SW, CMD_SR, CMD_ER, CMD_CA, CMD_AX,
   CMD_AY, CMD_DX, CMD_DY, CMD_TS, CMD_TP, CMD_SP, CMD_SS, CMD_GV, CMD_RV, CMD_GH, CMD_RH, CMD_IR,
   CMD_IP, CMD_IC, CMD_IL, CMD_JX, CMD_JY, CMD_JZ, CMD_JT, CMD_JS, CMD_JP, CMD_JR, CMD_JH,
   CMD_IT, CMD_KH, CMD_MS, CMD_AC, CMD_MA, CMD_WA, CMD_RO, CMD_IW, CMD_BT, CMD_HL, CMD_HR, CMD_HM,


### PR DESCRIPTION
I think it would be good to have this command `AT RC` for resetting a single slot to default values. Thus I don't have to save a default configuration in the GUI and the firmware is the only source of the default settings.