### PR TITLE
Added fixes for keystring buffer, bumping version to 2.12.1

### DIFF
--- a/FLipWare/FlipWare.h
+++ b/FLipWare/FlipWare.h
@@ -35,8 +35,9 @@
 #include "bluetooth.h"
 #include "hid_hal.h"
 
-#define VERSION_STRING "v2.12"
+#define VERSION_STRING "v2.12.1"
 
+//  V2.12.1: fixed keystring buffer problem
 //  V2.12: improved modularisation and source code documentation, added LC-display support and elliptical deadzone
 //  V2.11: eeprom access optimization and support for deletion / update of individual slots
 //  V2.10: code size reduction: using floating point math, removed debug level control via AT E0, AT E1 and AT E2

--- a/FLipWare/buttons.cpp
+++ b/FLipWare/buttons.cpp
@@ -42,7 +42,8 @@ char * getButtonKeystring(int num)
 {
   char * str = keystringBuffer;
   for (int i=0;i<num;i++) {
-    while (*str++);    
+    if(*str) while(*str++);    
+    else str++;  
   }
   return(str);
 }
@@ -79,7 +80,16 @@ uint16_t setButtonKeystring(uint8_t buttonIndex, char * newKeystring)
   }
     
   strcpy (keystringAddress, newKeystring);  // store the new keystring!
-  buttonKeystrings[buttonIndex] = keystringAddress;  // remember it's address
+  
+  //update ALL keystring pointers, because we might have moved some of them
+  char * x = keystringBuffer;
+  for (int i=0;i<NUMBER_OF_BUTTONS;i++) {
+    if (*x) {
+      buttonKeystrings[i] = x;
+      while (*x++);
+    } else x++;
+  }
+  
   slotSettings.keystringBufferLen += delta;  // update buffer length
   
 #ifdef DEBUG_OUTPUT_FULL


### PR DESCRIPTION
When moving a keystring within the keystringbuffer, only the pointer to the new string was updated.

The remaining (especially following) keystring pointers were not updated, therefor when changing a config,
some parameters got lost.

This doesn't happen within the WebGUI much, because it sequentially updates all buttons (IMHO).
